### PR TITLE
Update AutoSplitter Action to avoid run failure

### DIFF
--- a/.github/workflows/autosplitters-xml.yml
+++ b/.github/workflows/autosplitters-xml.yml
@@ -23,4 +23,4 @@ jobs:
           git config --global user.name "GitHub Action"
           git add .
           git commit -m "Update LiveSplit.AutoSplitters.xml" || true
-          git push https://action:${{ secrets.GITHUB_TOKEN }}@github.com/LiveSplit/LiveSplit.git
+          git push https://action:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git


### PR DESCRIPTION
Since forks not necessarily should push to the actual LiveSplit repo, making it context sensitive (aka pushing to the current repo instead of hard-coding LiveSplit/LiveSplit) should avoid constant failures.